### PR TITLE
Feature/scripture navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bible-reference-rcl",
-  "version": "0.1.13",
+  "version": "0.2.0",
   "main": "dist/index.js",
   "repository": {
     "type": "git",

--- a/src/components/BibleReference/useBibleReference.js
+++ b/src/components/BibleReference/useBibleReference.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState } from "react";
 import isequal from 'lodash.isequal';
 import _ from 'lodash';
 import {
@@ -75,7 +75,7 @@ const useBibleReference = (props) => {
   const initialVerses_ = getVerseList(initialBook_, initialChapter_);
   const initialVerse_ = doSanityCheck(initialVerses_, initialVerse);
 
-  const [bookChapterVerses, setBookChapterVerses] = useState(BOOK_CHAPTER_VERSES);
+  const [bookChapterVerses, setBookChapterVerses_] = useState(BOOK_CHAPTER_VERSES);
   const [bookFullList, setFullBookList] = useState(bibleList_);
   const [bookList, setBookList] = useState(bibleList_);
   const [bookId, setBookId] = useState(initialBook_);
@@ -106,6 +106,17 @@ const useBibleReference = (props) => {
   }
 
   /**
+   * update chapter list And Verse Counts for books.  It only updates book IDs passed.
+   * @param bookChapterVerses - an object of book IDs that contains chapters that contain the verse counts (see BOOK_CHAPTER_VERSES for example)
+   */
+  const setBookChapterVerses = (bookChapterVerses) => {
+    if (bookChapterVerses) {
+      const newBCV = { ...BOOK_CHAPTER_VERSES, ...bookChapterVerses }
+      setBookChapterVerses_(newBCV)
+    }
+  };
+
+  /**
    * replace list of supported books shown to user
    * @param newBookList - an array of autocomplete objects where `key` is the book id and `label` is the localized string displayed to the user
    */
@@ -130,25 +141,25 @@ const useBibleReference = (props) => {
     }
   };
 
-  const goToPrevBook = () => {
+  const goToPrevBook = (event=null, selectVerse=USE_FIRST) => {
     // console.log(`useBibleReference.onPrevBook() ${bookId}`);
-    let { key: newBook, overflow } = getPrevItem(bibleList_, bookId);
+    let { key: newBook, overflow } = getPrevItem(bookList, bookId);
 
     if (overflow) {
       // TODO what do we do when we hit the beginning of the bible?
     } else {
-      goToBookChapterVerse(newBook, USE_LAST, USE_LAST);
+      goToBookChapterVerse(newBook, USE_LAST, selectVerse);
     }
   };
 
-  const goToNextBook = () => {
+  const goToNextBook = (event=null, selectVerse=USE_FIRST) => {
     // console.log(`useBibleReference.onNextBook() ${bookId}`);
-    let { key: newBook, overflow } = getNextItem(bibleList_, bookId);
+    let { key: newBook, overflow } = getNextItem(bookList, bookId);
 
     if (overflow) {
       // TODO what do we do when we hit the end of the bible?
     } else {
-      goToBookChapterVerse(newBook, USE_FIRST, USE_FIRST);
+      goToBookChapterVerse(newBook, USE_FIRST, selectVerse);
     }
   };
 
@@ -221,25 +232,25 @@ const useBibleReference = (props) => {
     }
   };
 
-  const goToPrevChapter = (event, selectVerse=USE_FIRST) => {
+  const goToPrevChapter = (event=null, selectVerse=USE_FIRST) => {
     // console.log(`useBibleReference.onPrevChapter() ${bookId} ${chapter}`);
     let { key: newChapter, overflow } = getPrevItem(chapterList, chapter);
 
     if (overflow) {
       // console.log(`useBibleReference.onPrevChapter() overflow`);
-      goToPrevBook();
+      goToPrevBook(event, selectVerse);
     } else {
       goToBookChapterVerse(bookId, newChapter, selectVerse);
     }
   };
 
-  const goToNextChapter = (event, selectVerse=USE_FIRST) => {
+  const goToNextChapter = (event=null, selectVerse=USE_FIRST) => {
     // console.log(`useBibleReference.onNextChapter() ${bookId} ${chapter}`);
     let { key: newChapter, overflow } = getNextItem(chapterList, chapter);
 
     if (overflow) {
       // console.log(`useBibleReference.onNextChapter() overflow`);
-      goToNextBook();
+      goToNextBook(event, selectVerse);
     } else {
       goToBookChapterVerse(bookId, newChapter, selectVerse);
     }
@@ -307,7 +318,8 @@ const useBibleReference = (props) => {
       onChangeBook,
       onChangeChapter,
       onChangeVerse,
-      setNewBookList
+      setNewBookList,
+      setBookChapterVerses,
     }
   };
 };


### PR DESCRIPTION
## Describe what your pull request addresses
- in useBibleReference()
  - added missing method setBookChapterVerses()
  - fixes for book, chapter and verse rollovers

## Testing:
- verify in https://github.com/unfoldingword/create-app/issues/5 MVP items 1 & 2, as well as check list at bottom of description
- can test with https://deploy-preview-55--create-app.netlify.app/

- [ ] go to account settings, change language to ru, click on the book select and should see only the 4 books translated:

![Screen Shot 2021-02-16 at 7 48 48 AM](https://user-images.githubusercontent.com/14238574/108065077-7db74700-702b-11eb-8fdd-d50971854f35.png)

- [ ] test previous and next chapter buttons to make sure roll-over works correctly on books and that verse is always set to 1 (note that clicking on previous verse should go to last verse of chapter on rollover)

- [ ] go to account settings, change language to hi, click on the book select and should see only the 2 books translated:

![Screen Shot 2021-02-16 at 7 50 46 AM](https://user-images.githubusercontent.com/14238574/108065271-c2db7900-702b-11eb-84e2-fd6638d1e4eb.png)

- [ ] test previous and next chapter buttons to make sure roll-over works correctly on books and that verse is always set to 1 (note that clicking on previous verse should go to last verse of chapter on rollover)

- [ ] go to account settings, change language to en, click on the book select and should see all the Bible books:

![Screen Shot 2021-02-16 at 7 52 12 AM](https://user-images.githubusercontent.com/14238574/108065443-03d38d80-702c-11eb-8a5a-b864694d3a4d.png)


