### PR TITLE
Feature kintsoogi 462 tab select

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bible-reference-rcl",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "main": "dist/index.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bible-reference-rcl",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "dist/index.js",
   "repository": {
     "type": "git",

--- a/src/components/ReferenceSelector/ReferenceSelector.js
+++ b/src/components/ReferenceSelector/ReferenceSelector.js
@@ -143,12 +143,49 @@ export function ReferenceSelector(props) {
     return null
   }
 
+  const changeSelectedValue = (oldValue, newValue) => {
+    const oldKey = oldValue.key
+    const newKey = newValue.key
+    if (onChange) {
+      onChange(newKey, oldKey).then(okToChange => {
+        // console.log(`ReferenceSelector(${id}).onChange() - changed approved: ${okToChange}`);
+        if (okToChange) {
+          setSelectedValue(newValue);
+          setTextboxValue(newKey);
+        } else { // change rejected, restore previous selection
+          // console.log(`ReferenceSelector(${id}).onChange() - restoring previous setting`, oldKey);
+          setSelectedValue(selectedValue);
+          setTextboxValue(oldKey);
+        }
+      })
+    } else {
+      setSelectedValue(newValue);
+      setTextboxValue(newKey);
+    }
+  }
+
+  /**
+   * Select the highlighted value on tab press
+   * @param {object} event event containing key press information
+   */
+  const handleKeyDown = event => {
+    if (event.key === 'Tab' && event.target.tagName === 'INPUT') {
+      const newKey = event.target.value
+      const newValue = options.find(option => option.key === newKey)
+      if (newValue) {
+        changeSelectedValue(selectedValue, newValue)
+      }
+    }
+  }
+
   // Render the UI for your table
   return (
     <Autocomplete
       id={`combo-box-${id}`}
       // autoComplete={true}
       // blurOnSelect={true}
+      autoComplete
+      autoHighlight
       clearOnBlur
       disableClearable={true}
       disableListWrap
@@ -198,25 +235,7 @@ export function ReferenceSelector(props) {
       value={selectedValue}
       onChange={(event, newValue) => { // when selected from menu
         if (newValue) {
-          const newKey = newValue['key'];
-          const oldKey = selectedValue['key'];
-          // console.log(`ReferenceSelector(${id}).onChange() - setting to ${newKey}`);
-          if (onChange) {
-            onChange(newKey, oldKey).then(okToChange => {
-              // console.log(`ReferenceSelector(${id}).onChange() - changed approved: ${okToChange}`);
-              if (okToChange) {
-                setSelectedValue(newValue);
-                setTextboxValue(newKey);
-              } else { // change rejected, restore previous selection
-                // console.log(`ReferenceSelector(${id}).onChange() - restoring previous setting`, oldKey);
-                setSelectedValue(selectedValue);
-                setTextboxValue(oldKey);
-              }
-            })
-          } else {
-            setSelectedValue(newValue);
-            setTextboxValue(newKey);
-          }
+          changeSelectedValue(selectedValue, newValue)
         } else {
           console.error(`ReferenceSelector(${id}).onChange() - invalid setting ${newValue}`);
         }
@@ -237,6 +256,7 @@ export function ReferenceSelector(props) {
           <TextField
             {...applyStylesToInput(params, style)}
             InputProps={{ ...params.InputProps, ...inputProps }}
+            onKeyDown={handleKeyDown}
           />
         )
       }}


### PR DESCRIPTION
# Describe what your pull request addresses

- [ ] Select Book, Chapter, or Verse on Tab

## Test Instructions

- [ ] Use this [deploy preview](https://deploy-preview-479--gateway-edit.netlify.app/)

![image](https://github.com/unfoldingWord/gateway-edit/assets/118755839/451741d0-a2f3-4bb5-9d03-e005c29ab007)

- [ ] Click on the Bible book auto-select in the header and use the arrow keys or keyboard to type/hover over a book of the Bible.
- [ ] Click the tab key and verify that the Bible book that you were hovering was selected. You should now be in the chapter autoselect.
- [ ] Repeat this process for the chapter and verse select.

solves #462 