### PR TITLE
Feature 623 / Auto Detect OBS and allow switching to OBS as a book

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bible-reference-rcl",
-  "version": "1.2.3-beta",
+  "version": "1.2.4-beta",
   "main": "dist/index.js",
   "repository": {
     "type": "git",

--- a/src/components/BibleReference/useBibleReference.js
+++ b/src/components/BibleReference/useBibleReference.js
@@ -1,4 +1,4 @@
-import {useState} from "react";
+import {useEffect, useState} from "react";
 import isequal from 'lodash.isequal';
 import _ from 'lodash';
 import {
@@ -139,6 +139,10 @@ const useBibleReference = (props) => {
   const [verseList, setVerseList] = useState(initialVerses_);
   const [verse, setVerse] = useState(initialVerse_);
 
+  useEffect(() => { // update bible list when OBS support changes
+    setFullBookList(bibleList_)
+  }, [addOBS]);
+
   const getFilteredBookList = () => {
     return _.cloneDeep(bookList);
   }
@@ -177,7 +181,6 @@ const useBibleReference = (props) => {
     goToBookChapterVerse_(bookId, chapter, verse, listOfBooks, newBCV) // reset to the original reference if possible
  }
 
-
   /**
    * replace list of supported books shown to user
    * @param newBookList - an array of autocomplete objects where `key` is the book id and `label` is the localized string displayed to the user
@@ -203,7 +206,7 @@ const useBibleReference = (props) => {
    */
   const applyBooksFilter = (filter, bookChapterVerses_ = bookChapterVerses) => {
     console.log(`useBibleReference.applyBooksFilter(${JSON.stringify(filter)})`);
-    const newBookList = filterBibleList(bookFullList, filter);
+    const newBookList = filterBibleList(getBibleList(null, addOBS), filter);
     if (newBookList?.length) { // sanity check, only apply filter if list is not empty
       updateBookList(newBookList, bookChapterVerses_);
     }


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ] fix bug where addOBS change was not updating bible list.

## Test Instructions

- [ ] test with https://deploy-preview-630--gateway-edit.netlify.app/
- [ ] select unfoldingword/en
- [ ] if it comes up with OBS already selected as a book and the obs/tn or obs/twl is not showing content
- [ ] after startup should be able to select obs and see OBS/tn and OBS/twl data:

<img width="1087" alt="Screenshot 2024-01-01 at 10 14 07 AM" src="https://github.com/unfoldingWord/translation-helps-rcl/assets/14238574/3f80b2ee-79b6-4108-ae33-a07cac1d8342">


- 
- [ ] select a regular book of the bible and make sure GWE still loads bible content:
